### PR TITLE
Don't return from terminalError

### DIFF
--- a/printer.ino
+++ b/printer.ino
@@ -266,6 +266,7 @@ inline void recoverableError() {
 inline void terminalError(unsigned int times) {
   flashErrorLEDs(times, 500);
   digitalWrite(errorLED, HIGH);
+  // no point in carrying on, so do nothing forevermore:
   while(true);
 }
 


### PR DESCRIPTION
This makes the sketch slightly smaller (saving 16 bytes under Arduino
1.0.1) and is consistent with how we currently terminate when
encountering a DHCP error.  It'll also make it easier to use
`terminalError` in the setup function.  Without this change, we would've
had to check the systemOK boolean to see whether we could continue with
setup.
