### PR TITLE
Abort if there are problems with the SD Card.

### DIFF
--- a/printer.ino
+++ b/printer.ino
@@ -114,7 +114,7 @@ inline void initPrinter() {
 inline void initSD() {
   pinMode(SD_Pin, OUTPUT);
   if (!SD.begin(SD_Pin)) {
-    debug("SD Card failure. Aborting.");
+    // SD Card failure.
     terminalError(2);
   }
 }


### PR DESCRIPTION
If there are problems opening the SD card for access then there's no
point continuing as we can't cache the data.

Slightly controversially, I've chosen the bump the error codes (number
of LED flashes) of a DHCP failure and cache failure.  I don't think this
is too much of a problem, partcularly because I've bumped the version
number.
