### PR TITLE
Spike towards server-controlled immediate printing.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -10,6 +10,8 @@ Sass::Plugin.options[:template_location] = 'public/stylesheets'
 use Sass::Plugin::Rack
 
 use Rack::MethodOverride
+use Printer::BackendServer::EncodedStatusHeaderMiddleare
+use Rack::ContentLength
 
 if ENV["RESQUE_SERVER"]
   require 'resque/server'

--- a/lib/printer/backend_server.rb
+++ b/lib/printer/backend_server.rb
@@ -7,6 +7,9 @@ module Printer::BackendServer
   autoload :Settings, "printer/backend_server/settings"
   autoload :Archive,  "printer/backend_server/archive"
 
+  autoload :EncodedStatusHeaderMiddleware,
+           "printer/backend_server/encoded_status_header_middleware"
+
   App = Rack::Builder.new do
     map("/printer")    { run Printer::BackendServer::Polling  }
     map("/preview")    { run Printer::BackendServer::Preview  }

--- a/lib/printer/backend_server/encoded_status_header_middleware.rb
+++ b/lib/printer/backend_server/encoded_status_header_middleware.rb
@@ -1,0 +1,21 @@
+class Printer::BackendServer::EncodedStatusHeaderMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+    headers.merge!("X-Printer-Encoded-Status" => encoded_status(status, headers))
+    [status, headers, body]
+  end
+
+  private
+
+  def encoded_status(status, headers)
+    [status, headers["Content-length"], encoded_presence(headers["X-Printer-PrintImmediately"])].compact.join("|")
+  end
+
+  def encoded_presence(header)
+    header ? 1 : 0
+  end
+end

--- a/test/backend_server/encoded_status_header_middleware_test.rb
+++ b/test/backend_server/encoded_status_header_middleware_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+require "rack/test"
+require "printer/backend_server"
+
+ENV['RACK_ENV'] = 'test'
+
+describe Printer::BackendServer::EncodedStatusHeaderMiddleware do
+  include Rack::Test::Methods
+
+  def app
+    Rack::Builder.new do
+      use Printer::BackendServer::EncodedStatusHeaderMiddleware
+      use Rack::ContentLength
+      run lambda { |env|
+        headers = env["PATH_INFO"] == "/print-now" ? {"X-Printer-PrintImmediately" => true} : {}
+        [200, headers, ["Response body"]]
+      }
+    end
+  end
+
+  describe "making a request" do
+    before do
+      get "anything"
+    end
+
+    it "includes the encoded header" do
+      assert last_response.headers.keys.include?("X-Printer-Encoded-Status")
+    end
+
+    it "encodes the status in the header" do
+      last_response.headers["X-Printer-Encoded-Status"].split("|")[0].must_equal "200"
+    end
+
+    it "encodes the content length in the header" do
+      last_response.headers["X-Printer-Encoded-Status"].split("|")[1].must_equal "Response body".length.to_s
+    end
+  end
+
+  describe "making a request where the X-Printer-PrintImmediately header is present" do
+    it "encodes the print immediately value into the header" do
+      get "/print-now"
+      last_response.headers["X-Printer-Encoded-Status"].split("|")[2].must_equal "1"
+    end
+  end
+end


### PR DESCRIPTION
This relates to #8, and explores using a single encoded header to
simplify parsing of more complex parameters from the server.
